### PR TITLE
Add SDR default association for LG UltraGear profile

### DIFF
--- a/install-lg-ultragear-no-dimming.ps1
+++ b/install-lg-ultragear-no-dimming.ps1
@@ -606,6 +606,8 @@ begin {
     # WCS default profile constants
     $CPT_ICC = 1  # COLORPROFILETYPE.CPT_ICC
     $CPS_DEV = 0  # COLORPROFILESUBTYPE.CPS_DEVICE
+    $COLOR_PROFILE_TYPE_SDR = 0  # COLORPROFILETYPE_STANDARD_DYNAMIC_RANGE
+    $COLOR_PROFILE_SUBTYPE_SDR = 0  # COLORPROFILESUBTYPE_STANDARD_DYNAMIC_RANGE
 
     Write-InitMessage "starting LG UltraGear no-dimming installer"
 
@@ -674,6 +676,16 @@ public static class WcsHdrAssoc {
 }
 "@
     Add-PInvokeType -Name 'WcsHdrAssoc.ColorProfileAddDisplayAssociation' -Code $srcHdrAssoc
+
+    $srcSdrAssoc = @"
+using System;
+using System.Runtime.InteropServices;
+public static class WcsSdrAssoc {
+  [DllImport("mscms.dll", CharSet=CharSet.Unicode, SetLastError=true, EntryPoint="ColorProfileSetDisplayDefaultAssociation")]
+  public static extern bool ColorProfileSetDisplayDefaultAssociation(string profile, string deviceName, uint scope, uint profileType, uint profileSubType, uint profileId);
+}
+"@
+    Add-PInvokeType -Name 'WcsSdrAssoc.ColorProfileSetDisplayDefaultAssociation' -Code $srcSdrAssoc
 
     $srcSendMessage = @"
 using System;
@@ -825,9 +837,21 @@ public static class Win32SendMessage {
                     }
                 }
 
+                try {
+                    if ($PSCmdlet.ShouldProcess($deviceName, "SDR/default association")) {
+                        [void][WcsSdrAssoc]::ColorProfileSetDisplayDefaultAssociation($installedPath, $deviceName, [uint32]$WCS_SCOPE_SYSTEM_WIDE, [uint32]$COLOR_PROFILE_TYPE_SDR, [uint32]$COLOR_PROFILE_SUBTYPE_SDR, 0)
+                        if ($PerUser.IsPresent) {
+                            [void][WcsSdrAssoc]::ColorProfileSetDisplayDefaultAssociation($installedPath, $deviceName, [uint32]$WCS_SCOPE_CURRENT_USER, [uint32]$COLOR_PROFILE_TYPE_SDR, [uint32]$COLOR_PROFILE_SUBTYPE_SDR, 0)
+                        }
+                        Write-SuccessMessage "SDR/default association ok"
+                    }
+                } catch {
+                    Write-NoteMessage "SDR association API not available; skipping."
+                }
+
                 if (-not $SkipHdrAssociation) {
                     try {
-                        # profileType 0 => ICC. No error if SDR.
+                        # profileType 0 => SDR/ICC association. Safe on non-HDR paths.
                         if ($PSCmdlet.ShouldProcess($deviceName, "HDR/advanced-color association")) {
                             [void][WcsHdrAssoc]::ColorProfileAddDisplayAssociation($installedPath, $deviceName, [uint32]$WCS_SCOPE_SYSTEM_WIDE, 0)
                             if ($PerUser.IsPresent) { [void][WcsHdrAssoc]::ColorProfileAddDisplayAssociation($installedPath, $deviceName, [uint32]$WCS_SCOPE_CURRENT_USER, 0) }

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@
 - the profile is copied (or refreshed in‑place) into `%WINDIR%\System32\spool\drivers\color`.
 - displays with friendly name containing "lg ultragear" are discovered via wmi.
 - the profile is associated with each matched display and set as default.
+- the sdr pipeline receives an explicit default association (hdr/advanced-color is also updated unless `-SkipHdrAssociation`).
 - system color settings are refreshed.
 
 


### PR DESCRIPTION
## Summary
- add Windows Color System interop to set the SDR/default display association for the embedded profile
- call the new SDR association for system and per-user scopes alongside existing default/HDR flows
- document the new SDR association behavior in the README

## Testing
- not run (pwsh unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6908b202834c8325b91075ee77647cae